### PR TITLE
Allow lowest deps (according to the conflict section) to be installed in dev

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
             -   name: Install Composer dependencies
                 uses: ramsey/composer-install@v2
                 with:
-                    dependency-versions: ${{ matrix.dependency }}
+                    dependency-versions: ${{ matrix.dependency-versions }}
 
             -   name: Run tests
                 run: make phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "~2.13.0",
-        "friendsofphp/php-cs-fixer": "^3.8",
-        "phpunit/phpunit": "^9.5",
-        "symfony/filesystem": "^5.4"
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpunit/phpunit": "^9.4.3",
+        "symfony/filesystem": "^5.4 || ^6.1"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
If the dev version is more restrictive then the conflict sections are not correctly tested, as this build shows.