### PR TITLE
fix: Update the configuration to reflect the new PHP-CS-Fixer and Symfony preset changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4 || ^8.0"
     },
     "conflict": {
-        "friendsofphp/php-cs-fixer": "<3.11.0,>=4.0",
+        "friendsofphp/php-cs-fixer": "<3.17.0,>=4.0",
         "phpunit/phpunit": "<9.4.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4 || ^8.0"
     },
     "conflict": {
-        "friendsofphp/php-cs-fixer": "<3.17.0,>=4.0",
+        "friendsofphp/php-cs-fixer": "<3.19.0,>=4.0",
         "phpunit/phpunit": "<9.4.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "ergebnis/composer-normalize": "~2.13.0",
         "fidry/makefile": "^0.2.1",
-        "friendsofphp/php-cs-fixer": "^3.11.0",
+        "friendsofphp/php-cs-fixer": "^3.19.0",
         "phpunit/phpunit": "^9.4.3",
         "symfony/filesystem": "^5.4 || ^6.1"
     },

--- a/src/FidryConfig.php
+++ b/src/FidryConfig.php
@@ -84,6 +84,7 @@ final class FidryConfig extends BaseConfig
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
         ],
+        'modernize_strpos' => false,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         // Keep semicolons on the last line of multiline statements
@@ -147,6 +148,7 @@ final class FidryConfig extends BaseConfig
         'php_unit_set_up_tear_down_visibility' => true,
         // Don't replace assertEquals() by assertSame()
         'php_unit_strict' => false,
+        'php_unit_data_provider_name' => false,
         'php_unit_test_class_requires_covers' => false,
         'php_unit_test_case_static_method_calls' => [
             'call_type' => 'self',
@@ -154,6 +156,7 @@ final class FidryConfig extends BaseConfig
         'pow_to_exponentiation' => true,
         'protected_to_private' => true,
         'self_static_accessor' => true,
+        'single_line_empty_body' => false,
         'single_line_throw' => false,
         'single_trait_insert_per_statement' => false,
         // Don't replace == by === as we use it to compare value objects

--- a/tests/FidryConfigTest.php
+++ b/tests/FidryConfigTest.php
@@ -136,7 +136,7 @@ class FidryConfigTest extends TestCase
     }
 
     /**
-     * @dataProvider minPhpVersion
+     * @dataProvider minPhpVersionProvider
      *
      * @param list<string> $expectedRules
      * @param list<string> $expectedIgnoredRules
@@ -159,7 +159,7 @@ class FidryConfigTest extends TestCase
         }
     }
 
-    public static function minPhpVersion(): iterable
+    public static function minPhpVersionProvider(): iterable
     {
         $php74Rule = '@PHP70Migration';
         $php80Rule = '@PHP80Migration';


### PR DESCRIPTION
- Disallow `modernize_strpos` which has been introduced by the preset `Symfony:risky` in PHP 7.4. It is kept for PHP 8.0+.
- Disallow `single_line_empty_body` which is introduced by the preset `PhpCsFixer`: I do not like it.
- Disallow `php_unit_data_provider_name` which is introduced by the preset `PhpCsFixer`: I use a different convention.
- Bump the minimum PHP-CS-Fixer version required to allow to configure the rules above.