### PR TITLE
fix: Allow to install PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^7.2 || ^8.0"
     },
     "conflict": {
         "friendsofphp/php-cs-fixer": "<3.19.0,>=4.0",


### PR DESCRIPTION
This package will not support it explicitely, but I do not want to block the installation on 7.2 due to
https://github.com/theofidry/cpu-core-counter.