### PR TITLE
fix: Fix the minimum PHP-CS-Fixer version required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "ergebnis/composer-normalize": "^2.13.0",
         "fidry/makefile": "^0.2.1 || ^1.0.0",
-        "friendsofphp/php-cs-fixer": "^3.32.0",
+        "friendsofphp/php-cs-fixer": "^3.76.0",
         "phpunit/phpunit": "^9.4.3 || ^10.0 || ^11.0 || ^12.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.1"
     },


### PR DESCRIPTION
The `setUnsupportedPhpVersionAllowed()` method used in #48 requires at least [3.76.0](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.76.0).